### PR TITLE
Remove two booleans from map iterators

### DIFF
--- a/gs-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
+++ b/gs-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
@@ -3472,7 +3472,7 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
             this.count++;
             if (this.position == HANDLE_ZERO)
             {
-            	position++;
+            	this.position++;
                 if (<name>ObjectHashMap.this.containsKey(EMPTY_KEY))
                 {
                     return <name>ObjectHashMap.EMPTY_KEY;
@@ -3480,7 +3480,7 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
             }
             if (this.position == HANDLE_ONE)
             {
-            	position++;
+            	this.position++;
                 if (<name>ObjectHashMap.this.containsKey(REMOVED_KEY))
                 {
                     return <name>ObjectHashMap.REMOVED_KEY;
@@ -3718,9 +3718,7 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         public class InternalKeyValuesIterator implements Iterator\<<name>ObjectPair\<V>\>
         {
             private int count;
-            private int position;
-            private boolean handledZero;
-            private boolean handledOne;
+            private int position = HANDLE_ZERO;
 
             public <name>ObjectPair\<V> next()
             {
@@ -3730,17 +3728,17 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
                 }
                 this.count++;
 
-                if (!this.handledZero)
-                {
-                    this.handledZero = true;
+				if (this.position == HANDLE_ZERO)
+				{
+					this.position++;
                     if (<name>ObjectHashMap.this.containsKey(EMPTY_KEY))
                     {
                         return PrimitiveTuples.pair(EMPTY_KEY, <name>ObjectHashMap.this.sentinelValues.zeroValue);
                     }
                 }
-                if (!this.handledOne)
+                if (this.position == HANDLE_ONE)
                 {
-                    this.handledOne = true;
+                	this.position++;
                     if (<name>ObjectHashMap.this.containsKey(REMOVED_KEY))
                     {
                         return PrimitiveTuples.pair(REMOVED_KEY, <name>ObjectHashMap.this.sentinelValues.oneValue);

--- a/gs-collections-code-generator/src/main/resources/impl/map/mutable/primitivePrimitiveHashMap.stg
+++ b/gs-collections-code-generator/src/main/resources/impl/map/mutable/primitivePrimitiveHashMap.stg
@@ -1322,8 +1322,6 @@ public class <name1><name2>HashMap implements Mutable<name1><name2>Map, External
     {
         private int count;
         private int position = HANDLE_ZERO;
-        private boolean handledZero;
-        private boolean handledOne;
 
         public boolean hasNext()
         {
@@ -2499,9 +2497,7 @@ public class <name1><name2>HashMap implements Mutable<name1><name2>Map, External
         public class InternalKeyValuesIterator implements Iterator\<<name1><name2>Pair>
         {
             private int count;
-            private int position;
-            private boolean handledZero;
-            private boolean handledOne;
+            private int position = HANDLE_ZERO;
 
             public <name1><name2>Pair next()
             {
@@ -2511,17 +2507,17 @@ public class <name1><name2>HashMap implements Mutable<name1><name2>Map, External
                 }
                 this.count++;
 
-                if (!this.handledZero)
-                {
-                    this.handledZero = true;
+				if (this.position == HANDLE_ZERO)
+				{
+					this.position++;
                     if (<name1><name2>HashMap.this.containsKey(EMPTY_KEY))
                     {
                         return PrimitiveTuples.pair(EMPTY_KEY, <name1><name2>HashMap.this.sentinelValues.zeroValue);
                     }
                 }
-                if (!this.handledOne)
+                if (this.position == HANDLE_ONE)
                 {
-                    this.handledOne = true;
+                	this.position++;
                     if (<name1><name2>HashMap.this.containsKey(REMOVED_KEY))
                     {
                         return PrimitiveTuples.pair(REMOVED_KEY, <name1><name2>HashMap.this.sentinelValues.oneValue);


### PR DESCRIPTION
Remove handleZero/handleOne booleans from Iterators. Start iterating at -2, and use -2 and -1 as markers for zero and one sentinels.

Performance wise there seems to be no noticable changes in a quick test with 100 entries:

```
Benchmark                                                   Mode   Samples         Mean   Mean error    Units

Before change:
c.g.j.c.TestMapsBenchmark100.testIterate_GsIntObjectmap    thrpt        60     1017.885        1.211   ops/ms

After change
c.g.j.c.TestMapsBenchmark100.testIterate_GsIntObjectmap    thrpt        60     1013.230        3.875   ops/ms
c.g.j.c.TestMapsBenchmark100.testIterate_GsIntObjectmap    thrpt        60     1016.394        2.229   ops/ms
```
