### PR TITLE
Fixed POM files to generate correct OSGi Export-Package instructions

### DIFF
--- a/collections-api/pom.xml
+++ b/collections-api/pom.xml
@@ -273,7 +273,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Export-Package>com.gs.collections.api</Export-Package>
+                        <Export-Package>com.gs.collections.api.*</Export-Package>
                         <Bundle-RequiredExecutionEnvironment>J2SE-1.5,JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
                         <Import-Package>
                             net.jcip.annotations;resolution:=optional,*

--- a/collections/pom.xml
+++ b/collections/pom.xml
@@ -280,7 +280,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Export-Package>com.gs.collections.impl</Export-Package>
+                        <Export-Package>com.gs.collections.impl.*</Export-Package>
                         <Bundle-RequiredExecutionEnvironment>J2SE-1.5,JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
                         <Import-Package>
                             net.jcip.annotations;resolution:=optional,*


### PR DESCRIPTION
The instructions to generate OSGi Export-Package headers are not correct yet. The bundles don't resolve in an OSGi framework. This pull request fixes that.
